### PR TITLE
feat: rayon based find_starting_point

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ memmap = "0.7.0"
 serde = { version = "1.0.125", features = ["derive"] }
 string-builder = "0.2.0"
 itertools = "0.10.5"
+
+

--- a/src/debayer/amaze.rs
+++ b/src/debayer/amaze.rs
@@ -130,9 +130,9 @@ fn imagebuffer_to_vek_array(buffer: &ImageBuffer) -> Vek<Vek<f32>> {
     let mut image = vec_of_size(buffer.width * buffer.height, vec_of_size(3, 0.0_f32));
     for y in 0..buffer.height {
         for x in 0..buffer.width {
-            image[y * buffer.width + x][0] = buffer.get(x, y).unwrap_or(0.0);
-            image[y * buffer.width + x][1] = buffer.get(x, y).unwrap_or(0.0);
-            image[y * buffer.width + x][2] = buffer.get(x, y).unwrap_or(0.0);
+            image[y * buffer.width + x][0] = buffer.get(x, y);
+            image[y * buffer.width + x][1] = buffer.get(x, y);
+            image[y * buffer.width + x][2] = buffer.get(x, y);
         }
     }
 

--- a/src/debayer/malvar.rs
+++ b/src/debayer/malvar.rs
@@ -50,7 +50,7 @@ fn extract_window(
             } else {
                 mask_5x5_window[((ny + 2) * 5 + (nx + 2)) as usize] = true;
                 data_5x5_window[((ny + 2) * 5 + (nx + 2)) as usize] =
-                    buffer.get(bx as usize, by as usize).unwrap();
+                    buffer.get(bx as usize, by as usize);
             }
         }
     }

--- a/src/decompanding.rs
+++ b/src/decompanding.rs
@@ -58,7 +58,7 @@ fn get_lut_value_from_ilt_value(ilt_value: u32, ilt: &[u32; 256]) -> u32 {
 pub fn compand_buffer(buffer: &mut ImageBuffer, ilt: &[u32; 256]) {
     for x in 0..buffer.width {
         for y in 0..buffer.height {
-            let ilt_value = buffer.get(x, y).unwrap();
+            let ilt_value = buffer.get(x, y);
             let lut_value = get_lut_value_from_ilt_value(ilt_value as u32, ilt);
             buffer.put(x, y, lut_value as f32);
         }

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -306,7 +306,7 @@ impl Drawable for Image {
 
                         for channel in 0..num_channels {
                             let mut v = interpolated_color.get_channel_value(channel);
-                            let v0 = self.get_band(channel).get(x, y).unwrap() as f64;
+                            let v0 = self.get_band(channel).get(x, y) as f64;
                             if point_mask && avg_pixels && v0 > 0.0 {
                                 v = (v + v0) / 2.0;
                             }

--- a/src/guassianblur.rs
+++ b/src/guassianblur.rs
@@ -65,8 +65,7 @@ pub fn guassian_blur_nband(
                     let kernel_value = kernel[(kernel_i + r) as usize];
 
                     (0..buff_len).for_each(|b| {
-                        values[b] +=
-                            buffers[b].get(x - kernel_i as usize, y).unwrap() * kernel_value;
+                        values[b] += buffers[b].get(x - kernel_i as usize, y) * kernel_value;
                     });
                 }
             });
@@ -88,8 +87,7 @@ pub fn guassian_blur_nband(
                     let kernel_value = kernel[(kernel_i + r) as usize];
                     (0..buff_len).for_each(|b| {
                         //FIXME: unsafe unwrap
-                        values[b] +=
-                            buffers[b].get(x, y - kernel_i as usize).unwrap() * kernel_value;
+                        values[b] += buffers[b].get(x, y - kernel_i as usize) * kernel_value;
                     });
                 }
             });

--- a/src/hotpixel.rs
+++ b/src/hotpixel.rs
@@ -37,7 +37,7 @@ fn isolate_window(buffer: &ImageBuffer, window_size: i32, x: usize, y: usize) ->
                 && get_y >= 0
                 && get_y < buffer.height as i32
             {
-                v.push(buffer.get(get_x as usize, get_y as usize).unwrap());
+                v.push(buffer.get(get_x as usize, get_y as usize));
             }
         }
     }
@@ -54,7 +54,7 @@ pub fn hot_pixel_detection(
 
     for y in 1..buffer.height - 1 {
         for x in 1..buffer.width - 1 {
-            let pixel_value = buffer.get(x, y).unwrap();
+            let pixel_value = buffer.get(x, y);
             let window = isolate_window(buffer, window_size, x, y);
             let z_score = stats::z_score(pixel_value, &window[0..]).unwrap();
             if z_score > threshold {
@@ -68,7 +68,7 @@ pub fn hot_pixel_detection(
                     z_score,
                 });
             } else {
-                map.put(x, y, buffer.get(x, y).unwrap());
+                map.put(x, y, buffer.get(x, y));
             }
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -531,7 +531,7 @@ impl Image {
         let mut v = std::f32::MIN;
 
         for i in 0..self.bands.len() {
-            let b = self.bands[i].get(x, y).unwrap();
+            let b = self.bands[i].get(x, y);
             if v == std::f32::MIN {
                 v = b;
             } else if v != b {
@@ -715,7 +715,7 @@ impl Image {
                 out_img.put_pixel(
                     x as u32,
                     y as u32,
-                    Luma([self.bands[band].get(x, y).unwrap().round() as u16]),
+                    Luma([self.bands[band].get(x, y).round() as u16]),
                 );
             }
         }
@@ -741,9 +741,9 @@ impl Image {
                     x as u32,
                     y as u32,
                     Rgba([
-                        self.bands[0].get(x, y).unwrap().round() as u16,
-                        self.bands[1].get(x, y).unwrap().round() as u16,
-                        self.bands[2].get(x, y).unwrap().round() as u16,
+                        self.bands[0].get(x, y).round() as u16,
+                        self.bands[1].get(x, y).round() as u16,
+                        self.bands[2].get(x, y).round() as u16,
                         if self.get_alpha_at(x, y) {
                             std::u16::MAX
                         } else {
@@ -775,9 +775,9 @@ impl Image {
                     x as u32,
                     y as u32,
                     Rgb([
-                        self.bands[0].get(x, y).unwrap().round() as u16,
-                        self.bands[1].get(x, y).unwrap().round() as u16,
-                        self.bands[2].get(x, y).unwrap().round() as u16,
+                        self.bands[0].get(x, y).round() as u16,
+                        self.bands[1].get(x, y).round() as u16,
+                        self.bands[2].get(x, y).round() as u16,
                     ]),
                 );
             }
@@ -816,7 +816,7 @@ impl Image {
                 out_img.put_pixel(
                     x as u32,
                     y as u32,
-                    Luma([self.bands[band].get(x, y).unwrap().round() as u8]),
+                    Luma([self.bands[band].get(x, y).round() as u8]),
                 );
             }
         }
@@ -843,9 +843,9 @@ impl Image {
                     x as u32,
                     y as u32,
                     Rgba([
-                        self.bands[0].get(x, y).unwrap().round() as u8,
-                        self.bands[1].get(x, y).unwrap().round() as u8,
-                        self.bands[2].get(x, y).unwrap().round() as u8,
+                        self.bands[0].get(x, y).round() as u8,
+                        self.bands[1].get(x, y).round() as u8,
+                        self.bands[2].get(x, y).round() as u8,
                         if self.get_alpha_at(x, y) {
                             std::u8::MAX
                         } else {
@@ -877,9 +877,9 @@ impl Image {
                     x as u32,
                     y as u32,
                     Rgb([
-                        self.bands[0].get(x, y).unwrap().round() as u8,
-                        self.bands[1].get(x, y).unwrap().round() as u8,
-                        self.bands[2].get(x, y).unwrap().round() as u8,
+                        self.bands[0].get(x, y).round() as u8,
+                        self.bands[1].get(x, y).round() as u8,
+                        self.bands[2].get(x, y).round() as u8,
                     ]),
                 );
             }

--- a/src/imagebuffer.rs
+++ b/src/imagebuffer.rs
@@ -488,10 +488,11 @@ impl ImageBuffer {
             .to_vector()
     }
 
-    pub fn get(&self, x: usize, y: usize) -> error::Result<f32> {
+    #[inline(always)]
+    pub fn get(&self, x: usize, y: usize) -> f32 {
         if x < self.width && y < self.height {
             let index = y * self.width + x;
-            Ok(self.buffer[index])
+            self.buffer[index]
         } else {
             panic!("Invalid pixel coordinates");
         }
@@ -508,10 +509,10 @@ impl ImageBuffer {
             let xd = x - xf;
             let yd = y - yf;
 
-            let v00 = self.get(xf as usize, yf as usize).unwrap();
-            let v01 = self.get(xc as usize, yf as usize).unwrap();
-            let v10 = self.get(xf as usize, yc as usize).unwrap();
-            let v11 = self.get(xc as usize, yc as usize).unwrap();
+            let v00 = self.get(xf as usize, yf as usize);
+            let v01 = self.get(xc as usize, yf as usize);
+            let v10 = self.get(xf as usize, yc as usize);
+            let v11 = self.get(xc as usize, yc as usize);
 
             let v0 = v10 * yd + v00 * (1.0 - yd);
             let v1 = v11 * yd + v01 * (1.0 - yd);
@@ -752,7 +753,7 @@ impl ImageBuffer {
 
         for y in 0..self.height {
             for x in 0..self.width {
-                let val = self.get(x, y).unwrap();
+                let val = self.get(x, y);
                 if val >= threshold {
                     ox += x as Dn;
                     oy += y as Dn;
@@ -813,7 +814,7 @@ impl ImageBuffer {
                     shifted_buffer.put(
                         shift_x as usize,
                         shift_y as usize,
-                        self.get(x as usize, y as usize).unwrap(),
+                        self.get(x as usize, y as usize),
                     );
                 }
             }
@@ -873,7 +874,7 @@ impl ImageBuffer {
 
         for y in 0..self.height {
             for x in 0..self.width {
-                let val = self.get(x, y).unwrap().round() as u8;
+                let val = self.get(x, y).round() as u8;
                 let a = if self.get_mask_at_point(x, y) {
                     std::u8::MAX
                 } else {
@@ -894,7 +895,7 @@ impl ImageBuffer {
 
         for y in 0..self.height {
             for x in 0..self.width {
-                let val = self.get(x, y).unwrap().round() as u16;
+                let val = self.get(x, y) as u16;
                 let a = if self.get_mask_at_point(x, y) {
                     std::u16::MAX
                 } else {
@@ -913,7 +914,7 @@ impl ImageBuffer {
 
         for y in 0..self.height {
             for x in 0..self.width {
-                let val = self.get(x, y).unwrap().round() as u16;
+                let val = self.get(x, y) as u16;
                 let a = if self.get_mask_at_point(x, y) {
                     std::u16::MAX
                 } else {
@@ -939,7 +940,7 @@ impl ImageBuffer {
 
         for y in 0..self.height {
             for x in 0..self.width {
-                let val = self.get(x, y).unwrap().round() as u8;
+                let val = self.get(x, y).round() as u8;
                 let a = if self.get_mask_at_point(x, y) {
                     std::u8::MAX
                 } else {

--- a/src/lowpass.rs
+++ b/src/lowpass.rs
@@ -1,24 +1,27 @@
 use crate::{image::Image, imagebuffer::ImageBuffer, stats};
 
 fn isolate_window(buffer: &ImageBuffer, window_size: usize, x: usize, y: usize) -> Vec<f32> {
-    let mut v: Vec<f32> = Vec::with_capacity(window_size * window_size);
     let start = -(window_size as i32 / 2);
     let end = window_size as i32 / 2 + 1;
-    for _y in start..end {
-        for _x in start..end {
-            let get_x = x as i32 + _x;
-            let get_y = y as i32 + _y;
-            if get_x >= 0
-                && get_x < buffer.width as i32
-                && get_y >= 0
-                && get_y < buffer.height as i32
-                && buffer.get_mask_at_point(get_x as usize, get_y as usize)
-            {
-                v.push(buffer.get(get_x as usize, get_y as usize).unwrap());
-            }
-        }
-    }
-    v
+
+    (start..end).fold(
+        Vec::with_capacity(window_size * window_size),
+        |mut acc, _y| {
+            (start..end).for_each(|_x| {
+                let get_x = x as i32 + _x;
+                let get_y = y as i32 + _y;
+                if get_x >= 0
+                    && get_x < buffer.width as i32
+                    && get_y >= 0
+                    && get_y < buffer.height as i32
+                    && buffer.get_mask_at_point(get_x as usize, get_y as usize)
+                {
+                    acc.push(buffer.get(get_x as usize, get_y as usize));
+                }
+            });
+            acc
+        },
+    )
 }
 
 fn mean_of_window(buffer: &ImageBuffer, window_size: usize, x: usize, y: usize) -> Option<f32> {

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -51,9 +51,9 @@ pub fn color_noise_reduction(image: &mut Image, amount: i32) -> Image {
 
     for y in 0..image.height {
         for x in 0..image.width {
-            let r = image.get_band(0).get(x, y).unwrap() as u8;
-            let g = image.get_band(1).get(x, y).unwrap() as u8;
-            let b = image.get_band(2).get(x, y).unwrap() as u8;
+            let r = image.get_band(0).get(x, y) as u8;
+            let g = image.get_band(1).get(x, y) as u8;
+            let b = image.get_band(2).get(x, y) as u8;
             let idx = (y * image.width) + x;
             data[idx][0] = r;
             data[idx][1] = g;

--- a/src/util.rs
+++ b/src/util.rs
@@ -86,9 +86,9 @@ pub fn replace_image_extension(input_file: &str, append: &str) -> String {
 pub fn vec_to_str(v: &[f64]) -> String {
     let mut b = Builder::default();
 
-    for item in v {
+    v.into_iter().for_each(|item| {
         b.append(format!("{},", item));
-    }
+    });
 
     let mut s = b.string().unwrap();
     if !s.is_empty() {

--- a/tests/image.rs
+++ b/tests/image.rs
@@ -60,19 +60,19 @@ fn test_rgbimage_math_3band() {
     assert_eq!(img.width, 1000);
     assert_eq!(img.height, 1000);
     assert_eq!(img.num_bands(), 3);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 200.0);
-    assert_eq!(img.get_band(1).get(100, 100).unwrap(), 200.0);
-    assert_eq!(img.get_band(2).get(100, 100).unwrap(), 200.0);
+    assert_eq!(img.get_band(0).get(100, 100), 200.0);
+    assert_eq!(img.get_band(1).get(100, 100), 200.0);
+    assert_eq!(img.get_band(2).get(100, 100), 200.0);
 
     img.apply_weight_on_band(0.1, 0);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 20.0);
-    assert_eq!(img.get_band(1).get(100, 100).unwrap(), 200.0);
-    assert_eq!(img.get_band(2).get(100, 100).unwrap(), 200.0);
+    assert_eq!(img.get_band(0).get(100, 100), 20.0);
+    assert_eq!(img.get_band(1).get(100, 100), 200.0);
+    assert_eq!(img.get_band(2).get(100, 100), 200.0);
 
     img.divide_from_each(&b0);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 0.2);
-    assert_eq!(img.get_band(1).get(100, 100).unwrap(), 2.0);
-    assert_eq!(img.get_band(2).get(100, 100).unwrap(), 2.0);
+    assert_eq!(img.get_band(0).get(100, 100), 0.2);
+    assert_eq!(img.get_band(1).get(100, 100), 2.0);
+    assert_eq!(img.get_band(2).get(100, 100), 2.0);
 }
 
 #[test]
@@ -97,23 +97,23 @@ fn test_rgbimage_math_1band() {
     assert_eq!(img.width, 1000);
     assert_eq!(img.height, 1000);
     assert_eq!(img.num_bands(), 1);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 200.0);
+    assert_eq!(img.get_band(0).get(100, 100), 200.0);
 
     img.add(&img2);
     assert_eq!(img.width, 1000);
     assert_eq!(img.height, 1000);
     assert_eq!(img.num_bands(), 1);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 300.0);
+    assert_eq!(img.get_band(0).get(100, 100), 300.0);
 
     img.add(&img3);
     assert_eq!(img.width, 1000);
     assert_eq!(img.height, 1000);
     assert_eq!(img.num_bands(), 1);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 500.0);
+    assert_eq!(img.get_band(0).get(100, 100), 500.0);
 
     img.apply_weight_on_band(0.1, 0);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 50.0);
+    assert_eq!(img.get_band(0).get(100, 100), 50.0);
 
     img.divide_from_each(&b0);
-    assert_eq!(img.get_band(0).get(100, 100).unwrap(), 0.5);
+    assert_eq!(img.get_band(0).get(100, 100), 0.5);
 }


### PR DESCRIPTION
# More ideas:

This one's much simpler (albeit touching more files)

- remove the `.unwrap()` calls everywhere due to the `ImageBuffer::get()` why? well because there's a `panic!` in there so.. as it's got no possible chance of returning the `Err` case, well.. it's useless.

- this `get` is also now decorated with a compiler hint to inline it all the time, the compiler can still disobey us, but hopefully this will bring about more speed, it's a commonly used trick in rust code that does a whole bunch of number crunching with the same function over n over again.

- gave the other 'slow' area some rayon treatment, it will work the same way as the last one.

- tests are all passing, to run them with the 'rayon' feature:
  `cargo test --features rayon`
  if the performance of tests is frustrating, you can pass the release flag there just as you would in a `cargo build`.
  `cargo test --features rayon --release`

- made some small `P` `AsRef<Path>` adjustments mentioned earlier.
